### PR TITLE
Correction de bug

### DIFF
--- a/fbos-cli.pl
+++ b/fbos-cli.pl
@@ -4,7 +4,7 @@ use warnings;
 
 package FBOS::Client;
 
-my $VERSION = "0.4";
+my $VERSION = "0.5";
 
 use LWP::UserAgent;
 use JSON qw/ from_json to_json /;
@@ -145,8 +145,9 @@ sub app_token {
     } else {
         my $auth_progress;
         $app_token = $self->login();
-        warn "Please confirm on the freebox\n";
+		$self->set_track_id( $app_token->{track_id} );
         do {
+			warn "Please confirm on the freebox\n";
             sleep 1;
             $self->auth_progress();
         } while ( $self->get_auth_progress() eq "pending" );

--- a/fbos-cli.pl
+++ b/fbos-cli.pl
@@ -302,6 +302,15 @@ sub api_dhcp_dynamic_lease {
     return $res;
 }
 
+sub api_set_dhcp_static_lease {
+    my ($self, $config, $id) = @_;
+    my $url = "dhcp/static_lease/";
+    $url .= $id if defined $id;
+    my $res = $self->PUT($url, undef, $config);
+    $self->err_msg();
+    return $res;
+}
+
 sub api_ftp_config {
     my ($self) = @_;
     my $res = $self->GET("ftp/config");


### PR DESCRIPTION
La méthode app_token ne stockait pas le track_id, empêchant le suivi de demande d'accès de fonctionner.
